### PR TITLE
fix: trivial correctness, i18n, and link hygiene improvements

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -58,7 +58,7 @@ export default async function BlogPostPage({
 						[merriweather.className]: !post.data.technical,
 					})}
 				/>
-				<EditPageBanner type="posts" lang="en" slug={params.slug} />
+				<EditPageBanner type="posts" lang={params.locale} slug={params.slug} />
 
 				<hr />
 

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { getProject } from '@/lib/projects'
 import type { PageProps } from '@/lib/types'
 
 type Params = {
-	slug: 'string'
+	slug: string
 }
 
 export const generateMetadata = getMetadata<{ params: { slug: string } }>(
@@ -53,7 +53,7 @@ export default async function BlogPostPage({
 				objectId={`project-${params.slug}`}
 			/>
 			<article dangerouslySetInnerHTML={{ __html: post?.contentHtml ?? '' }} />
-			<EditPageBanner type="projects" lang="en" slug={params.slug} />
+			<EditPageBanner type="projects" lang={params.locale} slug={params.slug} />
 		</>
 	)
 }

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -33,7 +33,7 @@ export const generateMetadata = getMetadata(() => ({
 	alternates: { canonical: `/projects` },
 }))
 
-export default async function Blog({ params: paramsPromise }: PageProps) {
+export default async function Projects({ params: paramsPromise }: PageProps) {
 	const params = await paramsPromise
 	const entries = getProjects(params.locale)
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 import type { ReactNode } from 'react'
 
 type Props = {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -35,7 +35,9 @@ export default function Modal(props: Props) {
 			}}
 		>
 			<div>
-				<button onClick={handleOnClose}>Close</button>
+				<button type="button" onClick={handleOnClose} aria-label="Close modal">
+					Close
+				</button>
 			</div>
 			{children}
 		</div>

--- a/src/components/Nft/index.tsx
+++ b/src/components/Nft/index.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image'
+
 import type { Nft } from '@/lib/open-sea'
 
 export default function NftInfo(props: Nft) {
@@ -5,7 +7,7 @@ export default function NftInfo(props: Nft) {
 		<div>
 			<h1>{props.name}</h1>
 			<p>{props.description}</p>
-			<img src={props.image_url} alt={props.name} />
+			<Image src={props.image_url} alt={props.name} width={500} height={500} />
 		</div>
 	)
 }

--- a/src/modules/AsideAboutMe/index.tsx
+++ b/src/modules/AsideAboutMe/index.tsx
@@ -29,7 +29,7 @@ export default function SideAboutMe() {
 				src="/apple-touch-icon.png"
 				width={40}
 				height={40}
-				alt=""
+				alt="César Guadarrama profile picture"
 			/>
 			<p className={sitename}>cesargdm</p>
 			<p className={smallDescription}>

--- a/src/modules/Chat/index.tsx
+++ b/src/modules/Chat/index.tsx
@@ -204,7 +204,7 @@ function Chat({ locale }: { locale: Locale }) {
 					/>
 					<button
 						type="submit"
-						disabled={state.isLoading || !prompt || !state.content}
+						disabled={state.isLoading || !state.content}
 						aria-label="Send message"
 						className={submitButton}
 					>

--- a/src/modules/HoverCompany/index.tsx
+++ b/src/modules/HoverCompany/index.tsx
@@ -49,7 +49,12 @@ export default function HoverCompany({ children }: { children: string }) {
 
 	return (
 		<span style={{ position: 'relative', display: 'inline' }}>
-			<a href={metadata.url} className={dropdownText}>
+			<a
+				href={metadata.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				className={dropdownText}
+			>
 				{children}
 				{Boolean(metadata.outOfBusiness) && (
 					<span

--- a/src/modules/LastPhoto/index.tsx
+++ b/src/modules/LastPhoto/index.tsx
@@ -39,7 +39,7 @@ async function LastPhoto() {
 							height={500}
 							className={image}
 							src={photo.urls.regular}
-							alt={data[0]?.alt_description ?? ''}
+							alt={photo.alt_description ?? ''}
 						/>
 					</div>
 				))}

--- a/src/modules/LastPost/index.tsx
+++ b/src/modules/LastPost/index.tsx
@@ -35,8 +35,8 @@ async function LastTweet() {
 			target="_blank"
 			rel="noopener noreferrer"
 			className={readTweetsButton}
-			href="https://twitter.com/cesargdm"
-			aria-label="Visit my Twitter profile"
+			href="https://x.com/cesargdm"
+			aria-label="Visit my X profile"
 		>
 			Read more posts
 		</a>

--- a/src/modules/Reading/index.tsx
+++ b/src/modules/Reading/index.tsx
@@ -45,7 +45,7 @@ export default async function Reading() {
 							className={bookAnchor}
 							rel="noopener noreferrer"
 						>
-							<img className={bookImage} src={book.image} alt="" />
+							<img className={bookImage} src={book.image} alt={book.title} />
 							<div
 								style={{ textAlign: 'center', marginTop: 16, height: '3rem' }}
 							>


### PR DESCRIPTION
- Modal: import useRouter from next/navigation (was next/router, would
  crash in App Router parallel route)
- LastPhoto: use per-photo alt_description instead of data[0]'s for all
  items in the map
- Chat: drop dead `!prompt` guard on submit button (prompt is the global
  window.prompt, always truthy)
- blog/[slug] and projects/[slug]: pass params.locale to EditPageBanner
  so Spanish pages link to Spanish markdown instead of hardcoded "en"
- projects/[slug]: fix Params type using literal 'string' instead of
  the string type
- projects/page: rename default export from Blog to Projects
- LastPost: update twitter.com URL and aria-label to x.com / X
- HoverCompany: add target=_blank rel=noopener noreferrer to external
  company links